### PR TITLE
Ignore sockets when creating tar

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -66,6 +66,11 @@ func collectFileTar(path string, info os.FileInfo, err error) error {
 	if err != nil {
 		return err
 	}
+	if info.Mode()&os.ModeSocket != 0 {
+		// ignore sockets
+		return nil
+	}
+
 	fmt.Println("Adding", path)
 
 	th, err := tar.FileInfoHeader(info, path)


### PR DESCRIPTION
Prevents situations as described in #9.