### PR TITLE
restore: only pull image if it doesn't already exist

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -166,10 +166,13 @@ func restore(filename string) error {
 
 func createContainer(backup Backup) (string, error) {
 	fmt.Println("Restoring Container with hostname:", backup.Config.Hostname)
-	fmt.Println("Pulling Image:", backup.Config.Image)
-	_, err := cli.ImagePull(ctx, backup.Config.Image, types.ImagePullOptions{})
+	_, _, err := cli.ImageInspectWithRaw(ctx, backup.Config.Image)
 	if err != nil {
-		return "", err
+		fmt.Println("Pulling Image:", backup.Config.Image)
+		_, err := cli.ImagePull(ctx, backup.Config.Image, types.ImagePullOptions{})
+		if err != nil {
+			return "", err
+		}
 	}
 	// io.Copy(os.Stdout, reader)
 


### PR DESCRIPTION
This is particularly handy if you've got a locally built image that's not from a registry.

When migrating hosts, I did 
```
# https://stackoverflow.com/a/37650072
docker save $(docker images -q) -o images.tar
docker images | sed '1d' | awk '{print $1 " " $2 " " $3}' > mydockersimages.list
```
then 
```
docker load < images.tar

while read REPOSITORY TAG IMAGE_ID
do
        echo "== Tagging $REPOSITORY $TAG $IMAGE_ID =="
        docker tag "$IMAGE_ID" "$REPOSITORY:$TAG"
done < mydockersimages.list
```
to manually move all images. 

This then speeds up the restore process as the images don't need to be all pulled down from the internet.