### PR TITLE
backup: print detailed backup progress as files are added

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -34,6 +34,7 @@ var (
 	optTar     = false
 	optAll     = false
 	optStopped = false
+	optVerbose = false
 
 	paths []string
 	tw    *tar.Writer
@@ -59,6 +60,10 @@ func collectFile(path string, info os.FileInfo, err error) error {
 		return err
 	}
 
+	if optVerbose {
+		fmt.Println("Adding", path)
+	}
+
 	paths = append(paths, path)
 	return nil
 }
@@ -72,7 +77,9 @@ func collectFileTar(path string, info os.FileInfo, err error) error {
 		return nil
 	}
 
-	fmt.Println("Adding", path)
+	if optVerbose {
+		fmt.Println("Adding", path)
+	}
 
 	th, err := tar.FileInfoHeader(info, path)
 	if err != nil {
@@ -285,5 +292,6 @@ func init() {
 	backupCmd.Flags().BoolVarP(&optTar, "tar", "t", false, "create tar backups")
 	backupCmd.Flags().BoolVarP(&optAll, "all", "a", false, "backup all running containers")
 	backupCmd.Flags().BoolVarP(&optStopped, "stopped", "s", false, "in combination with --all: also backup stopped containers")
+	backupCmd.Flags().BoolVarP(&optVerbose, "verbose", "v", false, "print detailed backup progress")
 	RootCmd.AddCommand(backupCmd)
 }


### PR DESCRIPTION
This small change brings choice whether to list files as they are either added to the files list or to the tar archive itself.
It came from the necessity to run several automated tar-backups on containers with very high file count, resulting in heavy unnecessary print operations.

This also brings consistency between the non-tar and tar output, as opposed to the current tar-only unavoidable verbosity.

```
$ ./docker-backup backup -t testme
Creating backup of testme (alpine, ca1948afd7da)
Created backup: alpine-testme.tar
```
```
$ ./docker-backup backup -tv testme
Creating backup of testme (alpine, ca1948afd7da)
Adding /var/lib/docker/volumes/testmyvol/_data
Adding /var/lib/docker/volumes/testmyvol/_data/1
Adding /var/lib/docker/volumes/testmyvol/_data/10
Adding /var/lib/docker/volumes/testmyvol/_data/11
Adding /var/lib/docker/volumes/testmyvol/_data/12
Adding /var/lib/docker/volumes/testmyvol/_data/13
Adding /var/lib/docker/volumes/testmyvol/_data/14
Adding /var/lib/docker/volumes/testmyvol/_data/15
Adding /var/lib/docker/volumes/testmyvol/_data/16
Adding /var/lib/docker/volumes/testmyvol/_data/17
Adding /var/lib/docker/volumes/testmyvol/_data/18
Adding /var/lib/docker/volumes/testmyvol/_data/19
Adding /var/lib/docker/volumes/testmyvol/_data/2
Adding /var/lib/docker/volumes/testmyvol/_data/20
Adding /var/lib/docker/volumes/testmyvol/_data/3
Adding /var/lib/docker/volumes/testmyvol/_data/4
Adding /var/lib/docker/volumes/testmyvol/_data/5
Adding /var/lib/docker/volumes/testmyvol/_data/6
Adding /var/lib/docker/volumes/testmyvol/_data/7
Adding /var/lib/docker/volumes/testmyvol/_data/8
Adding /var/lib/docker/volumes/testmyvol/_data/9
Adding /var/lib/docker/volumes/testmyvol/_data/ishere
Created backup: alpine-testme.tar
$ 
```